### PR TITLE
Simplify tokenURI method

### DIFF
--- a/src/S33Ds.sol
+++ b/src/S33Ds.sol
@@ -42,18 +42,9 @@ contract S33Ds is ERC721, Ownable {
         }
     }
 
-
     function tokenURI(uint256 _tokenId) public view virtual override returns (string memory) {
         require(ownerOf[_tokenId] != address(0));
-
-        return string(
-            abi.encodePacked(
-                abi.encodePacked(
-                    baseURI,
-                    Strings.toString(_tokenId)
-                ), ".json"
-            )
-        );
+        return string(abi.encodePacked(baseURI, Strings.toString(_tokenId), ".json"));
     }
 
     function updateTokenCost(uint256 _tokenCost) external onlyOwner {


### PR DESCRIPTION
Use `abi.encodePacked()` once instead of twice.